### PR TITLE
chore: replace raw brew with p6df::modules::homebrew::cmd::brew in lib/util.sh

### DIFF
--- a/lib/util.sh
+++ b/lib/util.sh
@@ -67,7 +67,7 @@ p6df::modules::homebrew::util::casks::remove() {
 p6df::modules::homebrew::brews::remove() {
 
     local formuli
-    formuli=$(brew list --formula)
+    formuli=$(p6df::modules::homebrew::cmd::brew list --formula)
 
     local formula
     for formula in $formuli; do


### PR DESCRIPTION
## Summary

- Replace raw `brew list --formula` with `p6df::modules::homebrew::cmd::brew list --formula` in `lib/util.sh:70` for consistent behavior

## Test plan

- [ ] `p6df::modules::homebrew::brews::remove` lists and removes formulae correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)